### PR TITLE
Add back the theme fontConfig

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,22 +14,22 @@ import {
 } from 'react-native-paper';
 import Splash from './components/splash';
 
-// const fontConfig = {
-//   default: {
-//     regular: {
-//       fontFamily: 'Roboto',
-//     },
-//     medium: {
-//       fontFamily: 'Roboto',
-//     },
-//     light: {
-//       fontFamily: 'Roboto',
-//     },
-//     thin: {
-//       fontFamily: 'Roboto',
-//     },
-//   },
-// };
+const fontConfig = {
+  default: {
+    regular: {
+      fontFamily: 'Roboto',
+    },
+    medium: {
+      fontFamily: 'Roboto',
+    },
+    light: {
+      fontFamily: 'Roboto',
+    },
+    thin: {
+      fontFamily: 'Roboto',
+    },
+  },
+};
 
 const theme = {
   ...DefaultTheme,


### PR DESCRIPTION
This is the first step in researching using the Poppins custom font via Expo. The App.js file contains a fontConfig object for the app's theme. Currently the theme is using the Roboto font. At some point I will need to change this to Poppins.