### PR TITLE
Get custom fonts working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Project Code Name *Beagle*
+If the Poppins font is not recognized, then run the following command from the terminal ...
+```
+rm -rf ./node_modules/expo/node_modules/expo-font/
+```

--- a/components/splash.js
+++ b/components/splash.js
@@ -1,30 +1,34 @@
-// import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import React from "react";
 import { Surface, Text } from "react-native-paper";
 import { StyleSheet } from "react-native";
-import { AppLoading } from "expo";
-// import {
-//   useFonts,
-//   Poppins_300Light,
-//   Poppins_600SemiBold,
-// } from '@expo-google-fonts/poppins';
+// import { AppLoading } from "expo";
+import {
+  useFonts,
+  Poppins_300Light,
+  Poppins_600SemiBold,
+} from '@expo-google-fonts/poppins';
 
 function Splash() {
-  // let [fontsLoaded] = useFonts({
-  //   Poppins_300Light: "../assets/fonts/Poppins_300Light.ttf",
-  //   Poppins_600SemiBold: "../assets/fonts/Poppins_600SemiBold.ttf",
-  // });
+  let [fontsLoaded] = useFonts({
+    Poppins_300Light,
+    Poppins_600SemiBold,
+  });
 
-  // if (!fontsLoaded) {
-  //   return <AppLoading />;
-  // } else {
+  if (fontsLoaded) {
     return (
       <Surface style={styles.surface}>
         <Text style={styles.titleText}>PillSmart</Text>
         <Text style={styles.tagLine}>building healthy habits</Text>
       </Surface>
     );
-  // }
+  } else {
+    return (
+      <Surface style={styles.surface}>
+        <Text style={{fontSize: 50}}>PillSmart</Text>
+      </Surface>
+    );
+  }
 }
 
 const styles = StyleSheet.create({
@@ -35,13 +39,13 @@ const styles = StyleSheet.create({
   },
   titleText: {
     fontSize: 50,
-    // fontFamily: "Poppins_600SemiBold",
+    fontFamily: "Poppins_600SemiBold",
     padding: 0,
     margin: 0,
   },
   tagLine: {
     fontSize: 15,
-    // fontFamily: "Poppins_300Light",
+    fontFamily: "Poppins_300Light",
     padding: 0,
     margin: 0,
   },


### PR DESCRIPTION
Turns out that there is an issue with Expo installing multiple versions of the fonts library. To get this working I simply ran the following command on the terminal ...

```
rm -rf ./node_modules/expo/node_modules/expo-font/
```